### PR TITLE
Tried to build with default cmd (debug build) and it failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You have to set the [CMAKE_PREFIX_PATH](https://cmake.org/cmake/help/latest/vari
 
 ```bash
 cmake -B build "-DCMAKE_PREFIX_PATH=/path/to/llvm;/path/to/qt"
-cmake --build build --parallel
+cmake --build build --parallel --config RelWithDebInfo
 ```
 
 It is important to surround the argument with quotes on Unix platforms, because the `;` appears to have a special meaning.


### PR DESCRIPTION
On windows I get
![image](https://user-images.githubusercontent.com/36543551/208389800-c51953ba-3385-4adb-98d3-8a8548ba33a8.png)

```
LLVMIRReader.lib(IRReader.cpp.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in mocs_compilation_Debug.obj [C:\AV_Disabled\REVIDE\build\REVIDE.vcxproj]
```
